### PR TITLE
Add: an extra variable which is needed in newer versions

### DIFF
--- a/JfrogDockerfile/Cracked.Example.Dockerfile
+++ b/JfrogDockerfile/Cracked.Example.Dockerfile
@@ -1,0 +1,4 @@
+FROM releases-docker.jfrog.io/jfrog/artifactory-pro:7.117.14
+USER root
+COPY --chown=artifactory:artifactory ./ArtifactoryAgent-1.0-790fix-SNAPSHOT-all.jar /opt/jfrog/artifactory/app/artifactory/ArtifactoryAgent.jar
+COPY --chown=artifactory:artifactory ./setenv.sh /opt/jfrog/artifactory/app/artifactory/tomcat/bin/setenv.sh

--- a/JfrogDockerfile/Example.docker-compose.yml
+++ b/JfrogDockerfile/Example.docker-compose.yml
@@ -1,0 +1,53 @@
+services:
+  artifactory:
+    image: jfrog-artifatcory-pro-cracked:7.117.14
+    environment:
+      - JF_SHARED_DATABASE_URL=jdbc:postgresql://postgresql:5432/artifactory
+      - JF_SHARED_DATABASE_DRIVER=org.postgresql.Driver
+      - JF_ROUTER_ENTRYPOINTS_EXTERNALPORT=8082
+      - JF_SHARED_DATABASE_TYPE=postgresql
+      - JF_SHARED_DATABASE_USERNAME=jfrog-pg-admin
+      - JF_SHARED_DATABASE_PASSWORD=<SECURE_PASSWORD>
+    ports:
+      - 8082:8082
+      - 8081:8081
+    volumes:
+      - ./jfrog-data:/var/opt/jfrog/artifactory
+      - /etc/localtime:/etc/localtime:ro
+    depends_on:
+      - postgresql
+    restart: always
+    logging:
+      driver: json-file
+      options:
+        max-size: "50m"
+        max-file: "10"
+    ulimits:
+      nproc: 65535
+      nofile:
+        soft: 32000
+        hard: 40000
+
+  postgresql:
+    image: postgres:16.6-alpine
+    container_name: postgresql
+    environment:
+      - POSTGRES_DB=artifactory
+      - POSTGRES_USER=jfrog-pg-admin
+      - POSTGRES_PASSWORD=<SECURE_PASSWORD>
+    ports:
+      - 5432:5432
+    volumes:
+      - ./jfrog-postgres:/var/lib/postgresql/data
+      - /etc/localtime:/etc/localtime:ro
+    restart: always
+    logging:
+      driver: json-file
+      options:
+        max-size: "50m"
+        max-file: "10"
+    ulimits:
+      nproc: 65535
+      nofile:
+        soft: 32000
+        hard: 40000

--- a/JfrogDockerfile/setenv.sh
+++ b/JfrogDockerfile/setenv.sh
@@ -1,0 +1,2 @@
+CATALINA_OPTS="-javaagent:/opt/jfrog/artifactory/app/artifactory/ArtifactoryAgent.jar"
+CATALINA_OPTS="$CATALINA_OPTS -Djf.product.home=/opt/jfrog/artifactory"

--- a/README.MD
+++ b/README.MD
@@ -1,6 +1,6 @@
 # ArtifactoryKeygen
 
-As it's named, this project is a keygen of Artifactory from JFrog. 
+As it's named, this project is a keygen of Artifactory from JFrog.
 
 Tested on 7.104.6 (Latest version), 7.9.2 (Latest version on [releases-docker](https://releases-docker.jfrog.io/))
 
@@ -17,21 +17,23 @@ If you think this project is useful to you please leave a star! Thanks!
 ---
 
 Click for different languages of this file
+
 - [English](README.MD)
 - [简体中文](README_CN.MD)
 
 Table of Contents
+
 - [ArtifactoryKeygen](#artifactorykeygen)
-    * [0x00 Installation](#0x00-installation)
-    * [0x01 Configuring the keygen [Optional]](#0x01-configuring-the-keygen--optional-)
-    * [0x02 Configuring the agent [Optional]](#0x02-configuring-the-agent--optional-)
-        + [Override default public key](#override-default-public-key)
-            - [By using the keygen](#by-using-the-keygen)
-            - [By your hands](#by-your-hands)
-    * [0x03 Other useful tools](#0x03-other-useful-tools)
-        + [Keygen](#keygen)
-    * [0x04 Compilation](#0x04-compilation)
-    * [0x05 TODOs and Future updates](#0x05-todos-and-future-updates)
+  - [0x00 Installation](#0x00-installation)
+  - [0x01 Configuring the keygen](#0x01-configuring-the-keygen)
+  - [0x02 Configuring the agent](#0x02-configuring-the-agent)
+    - [Override default public key](#override-default-public-key)
+      - [By using the keygen](#by-using-the-keygen)
+      - [By your hands](#by-your-hands)
+  - [0x03 Other useful tools](#0x03-other-useful-tools)
+    - [Keygen](#keygen)
+  - [0x04 Compilation](#0x04-compilation)
+  - [0x05 TODOs and Future updates](#0x05-todos-and-future-updates)
 
 ![](imgs/Success.png)
 
@@ -55,9 +57,13 @@ You'll need `ArtifactoryAgent` to patch some files.
 Navigate to Artifactory's Tomcat folder then edit `bin/setenv.sh` (It should be named `setenv.bat` on Windows)
 
 Add the following line to that file. Don't forget to change the path!
+
+For newer versions an additional variable is needed `jf.product.home`.
+
 ```shell
 # Linux / macOS(But why macOS??)
-CATALINA_OPTS=-javaagent:/path/to/ArtifactoryAgent-1.0-SNAPSHOT-all.jar
+CATALINA_OPTS="-javaagent:/path/to/ArtifactoryAgent-1.0-SNAPSHOT-all.jar"
+CATALINA_OPTS="$CATALINA_OPTS -Djf.product.home=/opt/jfrog/artifactory"
 ```
 
 ```batch
@@ -87,6 +93,7 @@ To be noticed that the public key should be a **RSA Public Key in X509 Format**
 and have at least 4096 bits of modulus of the key
 
 Copy the generated text and put it in agent arguments like this:
+
 ```shell
 # Linux
 CATALINA_OPTS=-javaagent:/path/to/ArtifactoryAgent-1.0-SNAPSHOT-all.jar=<GeneratedConfigHere>
@@ -111,8 +118,7 @@ Edit the template below and use Base64 to encode it then convert the encoded res
 
 You can get any text hexadecimal-ized by passing your text into the agent (Yes the agent is executable!)
 
-
-```
+```bash
 $ java -jar /path/to/ArtifactoryAgent-1.0-SNAPSHOT-all.jar <Text>
 ```
 


### PR DESCRIPTION
Changes:
let alone all the changes made via the markdown extension in code.

The main change is in lines [65](https://github.com/Lama3L9R/ArtifactoryKeygen/pull/12/files#diff-01e6d9ffed056a02cae8d8a0ec5d476a64d017bf85c0d5a94bb23ca21f33f5aaR65),[66](https://github.com/Lama3L9R/ArtifactoryKeygen/pull/12/files#diff-01e6d9ffed056a02cae8d8a0ec5d476a64d017bf85c0d5a94bb23ca21f33f5aaR66)


```bash
CATALINA_OPTS="-javaagent:/opt/jfrog/artifactory/app/artifactory/ArtifactoryAgent.jar"
CATALINA_OPTS="$CATALINA_OPTS -Djf.product.home=/opt/jfrog/artifactory"
```

Also Dockerfile and docker-compose, and setenv.sh examples have been added.